### PR TITLE
Skip people without uniqnames

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def createArcGISGroupsForAssignments(arcGIS, assignments, courseDictionary, cour
 
         groupNameAndID = util.formatNameAndID(group)
 
-        courseUsers = [user.login_id for user in courseUserDictionary[course.id]]
+        courseUsers = [user.login_id for user in courseUserDictionary[course.id] if (user.login_id is not None)]
         logger.info('Adding Canvas Users to ArcGIS Group {}: {}'.format(groupNameAndID, courseUsers))
 
         # ArcGIS usernames are U-M uniqnames with the ArcGIS organization name, separated by an underscore


### PR DESCRIPTION
Change to skip course people if they don't have a login_id (i.e., uniqname).  Most likely, those people haven't accepted the invitation to participate in the course, so they have the status "pending", and their information is not shown to the instructor.