### PR TITLE
Remove hard-coded course ID

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,7 +359,7 @@ def closeAllCourseLogHandlers():
 
 def getCourseIDsFromConfigCoursePage(canvas, courseID, pageName):
     VALID_COURSE_URL_REGEX = '^https://umich\.instructure\.com/courses/[0-9]+$'
-    pages = canvas.getCoursesPagesByNameObjects(138596, 'course-ids')  # type: list of CanvasObject
+    pages = canvas.getCoursesPagesByNameObjects(courseID, 'course-ids')  # type: list of CanvasObject
     courseIDs = None
 
     if pages:


### PR DESCRIPTION
While debugging problems with kartograafr in production, I discovered the ID of the original configuration course was hard-coded into the application!  I've replaced it with the proper variable and checked the code for any other hard-coded IDs.  No others were found.

@dlhaines, this is obviously an easy review.  You can either just approve it or take the opportunity to examine more of the code.