### PR TITLE
First version of debugging notebook

### DIFF
--- a/queries.ipynb
+++ b/queries.ipynb
@@ -10,7 +10,9 @@
     "## _⚠️ WARNING ⚠️_\n",
     "> Whenever this notebook is updated, before committing changes back to the git repository, **_remove all output_** from cells.  The output may contain PII about students, which should not be made public.\n",
     "\n",
-    "## Import kartograafr Code"
+    "## Import kartograafr Code\n",
+    "\n",
+    "> 💡**_Note_**: For some reason, in `main.py` the line `logger = None` needs to be commented out when used in this notebook.  It doesn't affect how the program runs outside of the notebook, though."
    ]
   },
   {
@@ -21,10 +23,7 @@
    "source": [
     "from main import *\n",
     "\n",
-    "# TODO: Move logging init to function, which is called by main()\n",
-    "logger = logging.getLogger(__name__)\n",
-    "logToStdOut()\n",
-    "logger"
+    "# TODO: Move logging init to function, which is called by main()"
    ]
   },
   {

--- a/queries.ipynb
+++ b/queries.ipynb
@@ -1,0 +1,341 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# kartograafr: Query Canvas and AGOL\n",
+    "\n",
+    "\n",
+    "## _⚠️ WARNING ⚠️_\n",
+    "> Whenever this notebook is updated, before committing changes back to the git repository, **_remove all output_** from cells.  The output may contain PII about students, which should not be made public.\n",
+    "\n",
+    "## Import kartograafr Code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from main import *\n",
+    "\n",
+    "# TODO: Move logging init to function, which is called by main()\n",
+    "logger = logging.getLogger(__name__)\n",
+    "logToStdOut()\n",
+    "logger"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to Canvas and ArcGIS Online (AGOL)\n",
+    "\n",
+    "### Set AGOL Connection Mode\n",
+    "Set `pro` to `True` below to connect to AGOL using _ArcGIS Pro_, which requires local installation of that application."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pro = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connect to AGOL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "if (pro):\n",
+    "    from arcgis import GIS\n",
+    "    arcGIS = GIS('pro')\n",
+    "\n",
+    "else:\n",
+    "    arcGIS = arcgisUM.getArcGISConnection(config.ArcGIS.SECURITYINFO)\n",
+    "\n",
+    "print( 'Login successful!' )\n",
+    "print( '  server: ' + arcGIS.properties.name )\n",
+    "print( '  user: ' + arcGIS.properties.user.username )\n",
+    "print( '  role: ' + arcGIS.properties.user.role )\n",
+    "\n",
+    "arcGIS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvas = getCanvasInstance()\n",
+    "canvas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query Canvas\n",
+    "\n",
+    "### Find Valid Outcome Object by ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outcomeID = config.Canvas.TARGET_OUTCOME_ID\n",
+    "validOutcome = canvas.getOutcomeObject(outcomeID)\n",
+    "\n",
+    "if not validOutcome:\n",
+    "    raise RuntimeError('Outcome ID {} not found'.format(outcomeID))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Find a Specific Course by ID and Outcome"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "courseID = 192894\n",
+    "matchingCourseIDs = getCourseIDsWithOutcome(canvas, [courseID], validOutcome)\n",
+    "\n",
+    "if len(matchingCourseIDs) == 0:\n",
+    "    raise RuntimeError('Course {} does not have outcome {}'.format(courseID, outcomeID))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Find Assignments from Course with Outcome\n",
+    "\n",
+    "**_Note_**: The first part of the output is from logging statements.  The second part is only the course's assignments with the desired outcome."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# TODO: Move the logging somewhere else\n",
+    "matchingCourseAssignments = getCourseAssignmentsWithOutcome(canvas, matchingCourseIDs, validOutcome)\n",
+    "\n",
+    "matchingCourseAssignments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Full Data of Matching Courses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Combine with function that only returns matchingCourseIDs?\n",
+    "courseDictionary = getCoursesByID(canvas, matchingCourseIDs)\n",
+    "courseDictionary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Courses' Users by Course IDs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "courseUserDictionary = getCoursesUsersByID(canvas, matchingCourseIDs)\n",
+    "courseUserDictionary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Data for Specific Course and Assignment\n",
+    "\n",
+    "Using the data structures returned by the functions above, pick out the full data for the \n",
+    "specific course (mentioned earlier) and for the first of all the assignments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "course = courseDictionary[courseID]\n",
+    "assignment = matchingCourseAssignments[0] # Only the first assignment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query AGOL\n",
+    "\n",
+    "### Construct the AGOL Assignment Group Name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groupTitle = '%s_%s_%s_%s' % (course.name, course.id, assignment.name, assignment.id)\n",
+    "groupTitle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query AGOL for the Group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group = arcgisUM.lookForExistingArcGISGroup(arcGIS, groupTitle)\n",
+    "group"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get List of Group Users\n",
+    "\n",
+    "**_Note_**: People are added to AGOL with username in the form of:\n",
+    "\n",
+    "\"_`uniqname`_`_umich`\"\n",
+    "\n",
+    "To compare with the usernames (AKA `login_id`) from Canvas, remove the \"`_umich`\" parts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groupUsers = arcgisUM.getCurrentArcGISMembers(group, 'groupNameAndID')\n",
+    "groupUsersTrimmed = [re.sub('_\\S+$', '', gu) for gu in groupUsers]\n",
+    "groupUsersTrimmed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare Users from AGOL and Canvas\n",
+    "\n",
+    "### Make List of Canvas Usernames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvasCourseUsers = [user.login_id for user in courseUserDictionary[course.id] if user.login_id is not None]\n",
+    "canvasCourseUsers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TODO: Complete This Notebook\n",
+    "\n",
+    "This notebook was started as a way to debug a specific problem.  At this point, the problem was revealed and nothing more was needed.  At some point, this notebook should be completed to demonstrate the other steps of the kartograafr process.\n",
+    "\n",
+    "In addition to debugging a specific problem, this notebook also points out a few things that should be changed in the kartograafr code:\n",
+    "\n",
+    "* To be used easily in Jupyter Notebook, it should become more like an API.\n",
+    "* Some functions log info, which is very useful when the program is running in production, but maybe not always desired in notebook output.\n",
+    "* Improve logging initialization, including a way to gracefully disable logging.\n",
+    "* Rather than querying for course IDs in one place, then query again for their full data, why not go for the full data in the first place?  Reduce the number of API calls."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
[I tried to add Peter (@knoopum) as a reviewer for this pull request, but GH won't let me add him.  I've invited him to join this repo.  Maybe he'll be able to review it after he accepts the invite.]

As I began debugging a recent problem with kartograafr/Canvas communications, I remembered Peter said he wanted to use kartograafr code from within Jupyter Notebook for support purposes.  So I began using JN for debugging this problem, thinking it could become the basis for a support notebook.  The document in this PR is the result.

As I put the notebook together, I realized for this to work really well, the kartograafr modules need to work more like an API than they do now.  You'll notice comments in the notebook about this.  I also stopped writing in the notebook when I'd gotten far enough to solve the problem at hand.  (Actually, I went a little further than necessary when I added the AGOL queries.  I was following the main application flow in the notebook.)

Prerequisites for running this notebook:

* Proper configuration for authentication with Canvas and AGOL.
* In `main.py`, the line `logger = None` needs to be commented out.  Not sure why, because it runs in production with that value.
