### PR TITLE
Passing sublists to ArcGIS add_users method to circumvent limits (#34)

### DIFF
--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -102,14 +102,17 @@ def addCanvasUsersToGroup(instructorLog, group, courseUsers):
     # ArcGIS usernames are U-M uniqnames with the ArcGIS organization name appended.
     arcGISFormatUsers = formatUsersNamesForArcGIS(courseUsers)
     logger.debug("addCanvasUsersToGroup: formatted: {}".format(arcGISFormatUsers))
-    
-    results = group.add_users(arcGISFormatUsers)
-    logger.debug("adding: results: {}".format(results))
 
-    usersNotAdded = results.get('notAdded')
-    """:type usersNotAdded: list"""
     usersCount = len(arcGISFormatUsers)
-    usersCount -= len(usersNotAdded) if usersNotAdded else 0
+    listsOfFormattedUsernames = util.splitListIntoSublists(arcGISFormatUsers, 20)
+
+    usersNotAdded = []
+    for listOfFormattedUsernames in listsOfFormattedUsernames:
+        results = group.add_users(listOfFormattedUsernames)
+        logger.debug("adding: results: {}".format(results))
+        usersNotAdded += results.get('notAdded')
+
+    usersCount -= len(usersNotAdded)
     logger.debug("usersCount: {}".format(usersCount))
     logger.debug("aCUTG: instructorLog 1: [{}]".format(instructorLog))
     instructorLog += 'Number of users added to group: [{}]\n\n'.format(usersCount)

--- a/util.py
+++ b/util.py
@@ -52,6 +52,11 @@ def elideString(string):
     return string
 
 
+def splitListIntoSublists(origList, sublistLength=10):
+    sublists = [origList[x:x + sublistLength] for x in range(0, len(origList), sublistLength)]
+    return sublists
+
+
 class Iso8601UTCTimeFormatter(logging.Formatter):
     """
     A logging Formatter class giving timestamps in a more common ISO 8601 format.


### PR DESCRIPTION
This PR introduces changes to `arcgisUM.py` and `utils.py` to circumvent a limit (25) to the number of users that can be added to an ArcGIS group at once using the `add_users` method. A new util function -- `splitListIntoSublists` -- breaks an existing list of strings into a list of smaller lists of a specified length. The relevant code in `arcgisUM.py` was updated to use this method and then iterate through the generated list of lists, reporting incremental results and accumulating a list of users not added. The PR aims to address issue #34.

Note: I am still thinking about how best to test this change, as it is difficult to find enough users with the proper configuration without using an actual course. I will provide updates as I figure out how to tackle this.