### PR TITLE
Remove Canvas account ID from configuration (#40)

### DIFF
--- a/configuration/config.py
+++ b/configuration/config.py
@@ -31,7 +31,6 @@ class Canvas(object):
     BASE_URL = ENV.get("Canvas_Base_URL", "https://umich.test.instructure.com")
     API_BASE_URL = BASE_URL + '/api/v1/'
     API_AUTHZ_TOKEN = ENV.get("Canvas_API_Token", "")
-    ACCOUNT_ID = ENV.get("Canvas_Account_ID", 306)  # Default is UM Canvas Test Account
     TARGET_OUTCOME_ID = 4353  # Canvas Outcome created for kartograafr
     CONFIG_COURSE_ID = ENV.get("Canvas_Config_Course_ID", 366944)
     CONFIG_COURSE_PAGE_NAME = 'course-ids'  # Not case-sensitive

--- a/configuration/secrets/env_blank.json
+++ b/configuration/secrets/env_blank.json
@@ -6,7 +6,6 @@
   "Canvas_Base_URL": "",
   "Canvas_API_Token": "",
   "Canvas_Config_Course_ID": 0,
-  "Canvas_Account_ID": 0,
   "ArcGIS_Org_Name": "",
   "ArcGIS_Username": "",
   "ArcGIS_Password": ""


### PR DESCRIPTION
This PR makes some small changes removing a mechanism to set the Canvas account ID, since investigation and testing suggested that it is not used by the application. The `CanvasAPI` module seems to rely on the base URL instead, which would determine whether the test, beta, or production Canvas account is in use. Thus, I removed the `CANVAS_ACCOUNT_ID` class variable from the `Canvas` class in `config.py` and the `Canvas_Account_ID` key-value pair from `env_blank.json` template. The PR aims to resolve issue #40.