### PR TITLE
Updating, combining functions for adding, removing users from ArcGIS groups (#34 and #43)

### DIFF
--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -2,6 +2,7 @@
 
 # standard modules
 import datetime, logging, json, traceback
+from operator import itemgetter
 from io import StringIO
 
 # third-party modules
@@ -23,6 +24,21 @@ logging.Handler.handleError = handleError
 TIMEZONE_UTC = dateutil.tz.tzutc()
 RUN_START_TIME = datetime.datetime.now(tz=TIMEZONE_UTC)
 RUN_START_TIME_FORMATTED = RUN_START_TIME.strftime('%Y%m%d%H%M%S')
+
+MODIFY_MODES = {
+    "add": {
+        "verb": "add",
+        "verbStem": "add",
+        "verbPrep": "to",
+        "methodName": "add_users"
+    },
+    "remove": {
+        "verb": "remove",
+        "verbStem": "remov",
+        "verbPrep": "from",
+        "methodName": "remove_users"
+    }
+}
 
 # Hold parsed options
 options = None
@@ -88,84 +104,61 @@ def getArcGISGroupByTitle(arcGISAdmin, title):
     return None
 
 
-def addCanvasUsersToGroup(group, courseUsers, instructorLog):
-    """Add new users to a specific ArcGIS group"""
+def modifyUsersInGroup(group: object, users: list, mode: str, instructorLog: str):
+    """Depending on the mode, add or remove users from the given ArcGIS group"""
 
-    logger.info("addCanvasUsersToGroup: enter")
+    logger.info("modifyUsersInGroup: enter")
     groupNameAndID = util.formatNameAndID(group)
-    
-    if len(courseUsers) == 0:
-        logger.info('No new users to add to ArcGIS Group {}'.format(groupNameAndID))
-        instructorLog += "No new users were added.\n\n"
+
+    # Set mode-specific methods and variables
+    if mode in MODIFY_MODES:
+        modeDict = MODIFY_MODES[mode]
+        verb, verbStem, verbPrep, methodName = itemgetter("verb", "verbStem", "verbPrep", "methodName")(modeDict)
+        modifyUsersMethod = getattr(group, methodName)
+        logger.debug(modifyUsersMethod)
+    else:
+        logger.error("Function was called with an invalid mode: " + mode)
+
+    if len(users) == 0:
+        logger.info(f"No users to {verb} {verbPrep} ArcGIS Group {groupNameAndID}")
+        instructorLog += f"No users were {verbStem}ed.\n\n"
+        logger.debug(f"modifyUsersInGroup: instructorLog: [\n{instructorLog}\n]")
         return instructorLog
 
-    logger.info('Adding Canvas Users to ArcGIS Group {}: {}'.format(groupNameAndID, courseUsers))
-    # ArcGIS usernames are U-M uniqnames with the ArcGIS organization name appended.
-    arcGISFormatUsers = formatUsersNamesForArcGIS(courseUsers)
-    logger.debug("addCanvasUsersToGroup: formatted: {}".format(arcGISFormatUsers))
+    logger.info(f"{verbStem}ing Canvas Users {verbPrep} ArcGIS Group {groupNameAndID}: {users}")
 
-    usersCount = len(arcGISFormatUsers)
+    # Change Canvas usernames to the ArcGIS format
+    # (ArcGIS usernames are U-M uniqnames with the ArcGIS organization name appended)
+    arcGISFormatUsers = formatUsersNamesForArcGIS(users)
+    logger.debug(f"modifyUsersInGroup: formatted: {arcGISFormatUsers}")
+
     listsOfFormattedUsernames = util.splitListIntoSublists(arcGISFormatUsers, 20)
-    usersNotAdded = []
+    usersNotModified = []
 
     for listOfFormattedUsernames in listsOfFormattedUsernames:
         try:
-            results = group.add_users(listOfFormattedUsernames)
-            logger.debug("adding: results: {}".format(results))
-            usersNotAdded += results.get('notAdded')
+            results = modifyUsersMethod(listOfFormattedUsernames)
+            logger.debug(f"{verbStem}ing: results: {results}")
+            usersNotModified += results.get(f"not{verbStem.capitalize()}ed")
         except RuntimeError as exception:
-            logger.error('Exception while adding users to ArcGIS group "{}": {}'.format(groupNameAndID, exception))
+            logger.error(f"Exception while {verbStem}ing users {verbPrep} ArcGIS group '{groupNameAndID}': {exception}")
             return None
 
-    usersCount -= len(usersNotAdded)
-    logger.debug("usersCount: {}".format(usersCount))
-    instructorLog += 'Number of users added to group: [{}]\n\n'.format(usersCount)
-    if usersNotAdded:
-        logger.warning('Warning: Some or all users not added to ArcGIS group {}: {}'.format(groupNameAndID, usersNotAdded))
-        instructorLog += 'Users not in group (these users need ArcGIS accounts created for them):\n' + '\n'.join(
-            ['* ' + userNotAdded for userNotAdded in usersNotAdded]
-        ) + '\n'
+    usersModifiedCount = len(arcGISFormatUsers) - len(usersNotModified)
+    logger.debug(f"usersModifiedCount: {usersModifiedCount}")
+    instructorLog += f"Number of users {verbStem}ed {verbPrep} group: [{usersModifiedCount}]\n\n"
+    if usersNotModified:
+        notModifiedMessage = f"Some or all users not {verbStem}ed {verbPrep} ArcGIS group"
+        if mode == "add":
+            notModifiedMessage += " (These users likely need ArcGIS accounts set up)"
+        logger.warning(
+            f"Warning: {notModifiedMessage} {groupNameAndID} : {usersNotModified}"
+        )
+        instructorLog += f"{notModifiedMessage}:\n" + "\n".join(
+            ["* " + userNotModified for userNotModified in usersNotModified]
+        ) + "\n"
 
-    logger.debug("addCanvasUsersToGroup: instructorLog: [{}]".format(instructorLog))
-    return instructorLog
-
-
-def removeCanvasUsersFromGroup(group, groupUsers, instructorLog):
-    """Remove a list of users from a specific Canvas group"""
-
-    logger.info("removeCanvasUsersFromGroup: enter")
-    groupNameAndID = util.formatNameAndID(group)
-
-    if not groupUsers:
-        logger.info('Existing ArcGIS group {} does not have users to remove.'.format(groupNameAndID))
-        instructorLog += "No past users were removed.\n\n"
-        return instructorLog
-
-    logger.info('Removing past Canvas users from ArcGIS Group [{}] [{}]'.format(groupNameAndID, ','.join(groupUsers)))
-
-    listsOfGroupUsers = util.splitListIntoSublists(groupUsers, 20)
-    usersNotRemoved = []
-    """:type usersNotRemoved: list"""
-
-    for listOfGroupUsers in listsOfGroupUsers:
-        try:
-            results = group.remove_users(listOfGroupUsers)
-            logger.debug("removing: results: {}".format(results))
-            usersNotRemoved += results.get('notRemoved')
-        except RuntimeError as exception:
-            logger.error('Exception while removing users from ArcGIS group "{}": {}'.format(groupNameAndID, exception))
-            return None
-
-    usersRemovedCount = len(groupUsers) - len(usersNotRemoved)
-    instructorLog += 'Number of users removed from group: [{}]\n\n'.format(usersRemovedCount)
-
-    if usersNotRemoved:
-        logger.warning('Warning: Some or all users not removed from ArcGIS group {}: {}'.format(groupNameAndID, usersNotRemoved))
-        instructorLog += 'Users that could not be removed:\n' + '\n'.join(
-            ['* ' + userNotRemoved for userNotRemoved in usersNotRemoved]
-        ) + '\n'
-
-    logger.debug("removeCanvasUsersFromGroup: instructorLog: [{}]".format(instructorLog))
+    logger.debug(f"modifyUsersInGroup: instructorLog: [\n{instructorLog}\n]")
     return instructorLog
 
 

--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -114,7 +114,7 @@ def addCanvasUsersToGroup(group, courseUsers, instructorLog):
             logger.debug("adding: results: {}".format(results))
             usersNotAdded += results.get('notAdded')
         except RuntimeError as exception:
-            logger.error('Exception while removing users from ArcGIS group "{}": {}'.format(groupNameAndID, exception))
+            logger.error('Exception while adding users to ArcGIS group "{}": {}'.format(groupNameAndID, exception))
             return None
 
     usersCount -= len(usersNotAdded)

--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -96,7 +96,7 @@ def addCanvasUsersToGroup(group, courseUsers, instructorLog):
     
     if len(courseUsers) == 0:
         logger.info('No new users to add to ArcGIS Group {}'.format(groupNameAndID))
-        instructorLog += "No new users were added.\n"
+        instructorLog += "No new users were added.\n\n"
         return instructorLog
 
     logger.info('Adding Canvas Users to ArcGIS Group {}: {}'.format(groupNameAndID, courseUsers))
@@ -126,7 +126,7 @@ def addCanvasUsersToGroup(group, courseUsers, instructorLog):
             ['* ' + userNotAdded for userNotAdded in usersNotAdded]
         ) + '\n'
 
-    logger.info("addCanvasUsersToGroup: instructorLog: [{}]".format(instructorLog))
+    logger.debug("addCanvasUsersToGroup: instructorLog: [{}]".format(instructorLog))
     return instructorLog
 
 
@@ -138,7 +138,7 @@ def removeCanvasUsersFromGroup(group, groupUsers, instructorLog):
 
     if not groupUsers:
         logger.info('Existing ArcGIS group {} does not have users to remove.'.format(groupNameAndID))
-        instructorLog += "No past users were removed.\n"
+        instructorLog += "No past users were removed.\n\n"
         return instructorLog
 
     logger.info('Removing past Canvas users from ArcGIS Group [{}] [{}]'.format(groupNameAndID, ','.join(groupUsers)))
@@ -165,6 +165,7 @@ def removeCanvasUsersFromGroup(group, groupUsers, instructorLog):
             ['* ' + userNotRemoved for userNotRemoved in usersNotRemoved]
         ) + '\n'
 
+    logger.debug("removeCanvasUsersFromGroup: instructorLog: [{}]".format(instructorLog))
     return instructorLog
 
 

--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -102,14 +102,17 @@ def addCanvasUsersToGroup(instructorLog, group, courseUsers):
     # ArcGIS usernames are U-M uniqnames with the ArcGIS organization name appended.
     arcGISFormatUsers = formatUsersNamesForArcGIS(courseUsers)
     logger.debug("addCanvasUsersToGroup: formatted: {}".format(arcGISFormatUsers))
-    
-    results = group.add_users(arcGISFormatUsers)
-    logger.debug("adding: results: {}".format(results))
 
-    usersNotAdded = results.get('notAdded')
-    """:type usersNotAdded: list"""
     usersCount = len(arcGISFormatUsers)
-    usersCount -= len(usersNotAdded) if usersNotAdded else 0
+    listsOfFormattedUsernames = util.splitListIntoSublists(arcGISFormatUsers, 20)
+
+    usersNotAdded = []
+    for listOfFormattedUsernames in listsOfFormattedUsernames:
+        results = group.add_users(listOfFormattedUsernames)
+        logger.debug("adding: results: {}".format(results))
+        usersNotAdded += results.get('notAdded')
+
+    usersCount -= len(usersNotAdded)
     logger.debug("usersCount: {}".format(usersCount))
     logger.debug("aCUTG: instructorLog 1: [{}]".format(instructorLog))
     instructorLog += 'Number of users added to group: [{}]\n\n'.format(usersCount)

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ def updateGroupUsers(courseUserDictionary, course, instructorLog, groupTitle, gr
     instructorLog += "Group: {} \n\n".format(groupNameAndID)
     instructorLog = arcgisUM.removeCanvasUsersFromGroup(group, changedArcGISGroupUsers, instructorLog)
     instructorLog = arcgisUM.addCanvasUsersToGroup(group, changedCourseUsers, instructorLog)
-    instructorLog += "\n- - - \n"
+    instructorLog += "\n- - -\n"
 
     return instructorLog
 

--- a/main.py
+++ b/main.py
@@ -142,9 +142,11 @@ def updateGroupUsers(courseUserDictionary, course, instructorLog, groupTitle, gr
     logger.info('Users to add from Canvas course for ArcGIS: Group {}: Canvas Users: {}'.format(groupNameAndID, changedCourseUsers))
     
     # Now update only the users in the group that have changed.
-    instructorLog, results = arcgisUM.removeSomeExistingGroupMembers(groupTitle, group, instructorLog, changedArcGISGroupUsers)  # @UnusedVariable
-    instructorLog = arcgisUM.addCanvasUsersToGroup(instructorLog, group, changedCourseUsers)
-    
+    instructorLog += "Group: {} \n\n".format(groupNameAndID)
+    instructorLog = arcgisUM.removeCanvasUsersFromGroup(group, changedArcGISGroupUsers, instructorLog)
+    instructorLog = arcgisUM.addCanvasUsersToGroup(group, changedCourseUsers, instructorLog)
+    instructorLog += "\n- - - \n"
+
     return instructorLog
 
 

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ def updateGroupUsers(courseUserDictionary, course, instructorLog, groupTitle, gr
     instructorLog += "Group: {} \n\n".format(groupNameAndID)
     instructorLog = arcgisUM.removeCanvasUsersFromGroup(group, changedArcGISGroupUsers, instructorLog)
     instructorLog = arcgisUM.addCanvasUsersToGroup(group, changedCourseUsers, instructorLog)
-    instructorLog += "\n- - -\n"
+    instructorLog += "- - -\n"
 
     return instructorLog
 

--- a/main.py
+++ b/main.py
@@ -132,19 +132,16 @@ def updateGroupUsers(courseUserDictionary, course, instructorLog, groupTitle, gr
     canvasCourseUsers = [user.login_id for user in courseUserDictionary[course.id] if user.login_id is not None]
     logger.debug('All Canvas users in course for Group {}: Canvas Users: {}'.format(groupNameAndID, canvasCourseUsers))
     
-    # compute the exact sets of users to change.
-    changedArcGISGroupUsers, changedCourseUsers = minimizeUserChanges(groupUsersTrimmed, canvasCourseUsers)
-    # added to avoid undefined variable warning
-    
-    # fix up the user name format for ArcGIS users names
-    changedArcGISGroupUsers = arcgisUM.formatUsersNamesForArcGIS(changedArcGISGroupUsers)
-    logger.info('Users to remove from ArcGIS: Group {}: ArcGIS Users: {}'.format(groupNameAndID, changedArcGISGroupUsers))
-    logger.info('Users to add from Canvas course for ArcGIS: Group {}: Canvas Users: {}'.format(groupNameAndID, changedCourseUsers))
-    
+    # Compute the exact sets of users to change.
+    usersToRemove, usersToAdd = minimizeUserChanges(groupUsersTrimmed, canvasCourseUsers)
+
+    logger.info('Users to remove from ArcGIS: Group {}: Users: {}'.format(groupNameAndID, usersToRemove))
+    logger.info('Users to add to ArcGIS: Group {}: Users: {}'.format(groupNameAndID, usersToAdd))
+
     # Now update only the users in the group that have changed.
-    instructorLog += "Group: {} \n\n".format(groupNameAndID)
-    instructorLog = arcgisUM.removeCanvasUsersFromGroup(group, changedArcGISGroupUsers, instructorLog)
-    instructorLog = arcgisUM.addCanvasUsersToGroup(group, changedCourseUsers, instructorLog)
+    instructorLog += f"Group: {groupNameAndID} \n\n"
+    instructorLog = arcgisUM.modifyUsersInGroup(group, usersToRemove, "remove", instructorLog)
+    instructorLog = arcgisUM.modifyUsersInGroup(group, usersToAdd, "add", instructorLog)
     instructorLog += "- - -\n"
 
     return instructorLog

--- a/util.py
+++ b/util.py
@@ -52,6 +52,11 @@ def elideString(string):
     return string
 
 
+def splitListIntoSublists(origList, sublistLength=10):
+    sublists = [origList[x:x + sublistLength] for x in range(0, len(origList), sublistLength)]
+    return sublists
+
+
 class Iso8601UTCTimeFormatter(logging.Formatter):
     """
     A logging Formatter class giving timestamps in a more common ISO 8601 format.

--- a/util.py
+++ b/util.py
@@ -52,7 +52,7 @@ def elideString(string):
     return string
 
 
-def splitListIntoSublists(origList, sublistLength=10):
+def splitListIntoSublists(origList: list, sublistLength: int=10):
     """Transform a given list into a list of lists of a specified maximum length"""
     sublists = [origList[x:x + sublistLength] for x in range(0, len(origList), sublistLength)]
     return sublists

--- a/util.py
+++ b/util.py
@@ -53,7 +53,7 @@ def elideString(string):
 
 
 def splitListIntoSublists(origList, sublistLength=10):
-    """Transform a given list into a list of lists of a specified length"""
+    """Transform a given list into a list of lists of a specified maximum length"""
     sublists = [origList[x:x + sublistLength] for x in range(0, len(origList), sublistLength)]
     return sublists
 

--- a/util.py
+++ b/util.py
@@ -53,6 +53,7 @@ def elideString(string):
 
 
 def splitListIntoSublists(origList, sublistLength=10):
+    """Transform a given list into a list of lists of a specified length"""
     sublists = [origList[x:x + sublistLength] for x in range(0, len(origList), sublistLength)]
     return sublists
 


### PR DESCRIPTION
This PR aims to fix functionality related to the addition and removal of users from ArcGIS groups by updating use of the ArcGIS API and adding a sublist creation utility function to circumvent API limits. It also combines and reorganizes two preexisting functions related to user removal into `removeCanvasUsersFromGroup` so as to align its algorithm and logging strategy with the `addCanvasUsersToGroup` function.  More details about these changes are provided below. This PR aims to resolve both issues #34 and #43.

1) A new utility function -- `splitListIntoSublists` -- breaks an existing list of strings into a list of smaller lists of a specified length. This function is now used in both the addition and removal functions to generate sub-lists of users to circumvent limits that seem to be imposed by the ArcGIS REST API. Both functions loop through these sub-lists, accumulating lists of users that failed either to be added or removed, which are then reported in the `instructorLog`.

2) When I started to investigate issue #43, I noticed that the two existing removal functions were set up quite differently from the addition function. To try to align the addition and removal functions (which use similar algorithms, despite essentially doing opposite things), I combined `removeListOfUsersFromArcGISGroup` and `removeSomeExistingGroupMembers`. I then examined the patterns the addition and removal code used to arrive at a consistent approach. That led me to adding some new lines accumulating more strings to `instructorLog` to both inform instructors of how many users were removed and if any users could not be removed. I also chose to incorporate a `try/except` into the addition function, which it did not have before. I also reorganized and simplified the function parameters to be similar to each other.

3) Lastly, I wrapped the lines from `updateGroupUsers` that invoke these functions with log messages  that include each course log with the `groupNameAndID` and a break symbol (`- - -`) to help divide the results of the updates to different assignments. Hopefully this will make the output more readable by instructors.