### PR TITLE
Updating README to reflect new processes, streamline formatting and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ staff. To designate a course and assignments in Canvas you would like synchroniz
 Once all of the above requirements are satisfied, kartograafr will synchronize your course's assignments with ArcGIS
 Online. It will happen automatically, several times each day.
 
-### For Administrators and Developers
+### For Administrators & Developers
 
 To set up the application, users will need to perform configuration steps in the Canvas and ArcGIS instances that they
 want to connect, and specify environment variables to access those instances and determine other application
@@ -136,7 +136,7 @@ To create your version of this file, do the following:
 1. Rename the file `env.json` (for use in local development) or `[some name].json` (for use in OpenShift).
 1. Replace the empty strings and `0`'s with the desired settings and values.
 
-The meaning of each key and its expected value are described in the table below.
+The meanings of the keys and their expected values are described in the table below.
 
 **Key** | **Description**
 ----- | -----

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The kartograafr application ...
 
 ### Use
 kartograafr is maintained by ITS Teaching & Learning at the University of Michigan. The unit runs the service to 
-support courses at the university that rely on ArcGIS for student assignments. Teaching & Learning currently runs the 
+support courses at the university that rely on ArcGIS for assignments. Teaching & Learning currently runs the 
 application as a scheduled job using [Docker](https://docs.docker.com/) containerization technology, the 
 [OpenShift Container Platform](https://docs.openshift.com/), and an instance of the 
 [Jenkins automation server](https://jenkins.io/doc/).
@@ -71,7 +71,7 @@ staff. To designate a course and assignments in Canvas you would like synchroniz
        "OK" button.
     1. After the import is complete, you will see "ArcGIS Group" in your course's list of outcomes.
 1. Each of your course's assignments which are to be synchronized with ArcGIS Online needs to include the "ArcGIS Group"
-   outcome in their rubrics. **_You will need to do this for each new assignment you add to the course._** This can be
+   outcome in its rubric. **_You will need to do this for each new assignment you add to the course._** This can be
    simplified somewhat by adding the "ArcGIS Group" outcome to a single rubric that will be used by multiple 
    assignments. Each assignment that uses that rubric will automatically include the "ArcGIS Group" outcome. It's 
    recommended that rubrics should be given meaningful names. For example, a good name could be "_your course name 
@@ -96,7 +96,7 @@ Online. It will happen automatically, several times each day.
 ### For Administrators and Developers
 
 To set up the application, users will need to perform configuration steps in the Canvas and ArcGIS instances that they
-want to connect, and specify environment variables to connect to those instances and determine other application
+want to connect, and specify environment variables to access those instances and determine other application
 settings. The following sections provide instructions for how to complete this configuration. (Note: UM-affiliated 
 users should contact Teaching & Learning, as much of this configuration is already in place.)
 
@@ -104,9 +104,9 @@ users should contact Teaching & Learning, as much of this configuration is alrea
 
 Within your instance of Canvas, do the following:
 
-1. Create an API access token.
+1. Create and record an API access token.
 1. Record the base URL of the Canvas API.
-1. Create an outcome for ArcGIS and record its ID number.
+1. Create an outcome for ArcGIS, and record its ID number.
 1. Create a kartograafr configuration course and record its ID number.
     1. Within the new configuration course, create a page named `course-ids`.
     1. Add to the page the URLs of courses to be processed (they will appear as links on the page).
@@ -116,7 +116,7 @@ Within your instance of Canvas, do the following:
 
 Within your instance of ArcGIS, do the following:
 
-1. Record the organization name in use (e.g., at UM, `devumich` or `umich`)
+1. Record the organization name in use (e.g., at UM, `devumich` or `umich`).
 1. Create a user with permission to create and modify user groups, and record the username and password.
 
 ### Application
@@ -128,22 +128,22 @@ classes defined in `config.py` (see the Installation section below for how to em
 
 The `env.json` file contains sensitive information, including account login information and an API secret, and thus 
 needs to be kept out of source control. Teaching & Learning maintains production, test, and local development versions 
-of these files outside of GitHub. A template JSON file called `env_blank.json` has been provided as a starting point.
+of this file outside of GitHub. A template JSON file called `env_blank.json` has been provided as a starting point.
 
 To create your version of this file, do the following:
 
 1. Copy `env_blank.json`.
 1. Rename the file `env.json` (for use in local development) or `[some name].json` (for use in OpenShift).
-1. Replace the empty strings and 0's with the desired settings and values.
+1. Replace the empty strings and `0`'s with the desired settings and values.
 
 The meaning of each key and its expected value are described in the table below.
 
 **Key** | **Description**
 ----- | -----
-`Logging_Level` | The minimum level for log messages that will appear in output. We recommend either `INFO` or `DEBUG` for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html) for more info.
-`Logging_Directory` | The path where log files will be written; in OpenShift, this needs to be the `tmp` directory of the container's file system.
+`Logging_Level` | The minimum level for log messages that will appear in output. `INFO` or `DEBUG` is recommended for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html) for more info.
+`Logging_Directory` | The path where log files will be written (see **OpenShift** under Installation & Development for a description of an OpenShift-related restriction on this value).
 `SMTP_Server` | The name of the server emails should be sent from, if the `--email` flag is in use.
-`Email_Sender_Address` | The name and email address to use in the FROM header of emails sent. This should take the form of "\"Severus Snape"\ <halfbloodprince@umich.edu>" (make sure to escape double quotes).
+`Email_Sender_Address` | The name and email address to use in the FROM header of emails sent. This should take the form of "\\"Severus Snape\\" <halfbloodprince@umich.edu>" (make sure to escape double quotes).
 `Canvas_Base_URL` | The URL of the Canvas instance you want to pull Canvas data from; for production at UM, this is `umich.instructure.com`.
 `Canvas_API_Token` | The API token to use when making requests for data related to courses, assignments, and users.
 `Canvas_Config_Course_ID` | The ID number of the configuration course, (see the **Canvas** configuration section above).
@@ -156,19 +156,19 @@ The meaning of each key and its expected value are described in the table below.
 ## <a name='installationAndDevelopment'></a>Installation & Development
 
 The sections below provide instructions for installing and running the application in various environments. Before
-attempting to install or deploy, ensure the configuration steps under **For Administrators and Developers** have been
-completed. Depending on the environment you plan to run the application in, you may also need to install some or all
-of the following:
+attempting to install or deploy, ensure the configuration steps under **For Administrators & Developers** in Configuration
+have been completed. Depending on the environment you plan to run the application in, you may also need to install some 
+or all of the following:
    * Python
    * Git
-   * Docker Desktop
-   * OpenShift CLI
+   * [Docker Desktop](https://www.docker.com/products/docker-desktop)
+   * [OpenShift CLI](https://docs.openshift.com/enterprise/3.1/cli_reference/get_started_cli.html)
 
 ### Local Development
 
 To set up the application for use locally or in preparation for development work, do the following:
 
-1. Clone the repository, and navigate into the repository.
+1. Clone the repository, and navigate into it.
    ```
    https://github.com/tl-its-umich-edu/kartograafr.git  # HTTPS
    git@github.com:tl-its-umich-edu/kartograafr.git  # SSH
@@ -213,7 +213,7 @@ kartograafr with this mock server, do the following:
    ```
 The email will appear in the window where you ran the Shell script.
 
-Alternatively, you can print the email content as part of application's output (without using the mock server) by 
+Alternatively, you can print the email content as part of the application's output (without using the mock server) by 
 passing the `--printEmail` flag when executing `main.py`.
 ```
 python main.py --email --printEmail
@@ -237,21 +237,25 @@ Note: Currently, there is no way to test sending emails using Docker on a local 
 
 ### OpenShift
 
-Running the application as a job using OpenShift and Jenkins involves several steps, which are beyond the scope of this 
+Deploying the application as a job using OpenShift and Jenkins involves several steps, which are beyond the scope of this 
 README. However, it seems appropriate to explain some configuration steps assumed by the `Dockerfile` and unique to this
 application.
 
-* The `env.json` file described during the Configuration steps needs to be made available to running kartograafr 
+* The `env.json` file described in Configuration needs to be made available to running kartograafr 
   containers via an OpenShift ConfigMap, a type of Resource. A volume containing the ConfigMap should be mapped to the 
   `configuration/secrets` subdirectory. These details will be specified a configuration file (.yaml) defining the 
   pod.
+
+* The kartograafr application writes log files as part of its normal operations. Because of permission restrictions 
+  within OpenShift pods, users may need to specify a path for `Logging_Directory` in `env.json` that begins with
+  `tmp`. The U-M configuration uses `tmp/log/kartograafr`.
 
 * By default, the application will run without sending email and with the assumption that the JSON file will be named 
   `env.json`. However, the `start.sh` invoked by the `Dockerfile` and `config.py` will also check whether the 
   environment variables `ENV_FILE` and `SEND_EMAIL` have been defined. These can be set using the pod configuration 
   file. To use a different name for the JSON file, set `ENV_FILE` to a path beginning with `configuration/secrets/`
-  and ending with the file name. To have the application send email, set `SEND_EMAIL` to the string `"True"`. The `env`
-  block in the `.yaml` will look something like the following:
+  and ending with the file name. To have the application send email, set `SEND_EMAIL` to the string `"True"`. With these
+  set, the `env` block in the `.yaml` will look something like the following:
 
   ```
   - env:

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ application.
   something like this:
   ```
   - env:
-     - name: ENV_FILE
-       value: /configuration/secrets/env_test.json
+      - name: ENV_FILE
+        value: /configuration/secrets/env_test.json
   ```
 
 ### Sending Email
@@ -284,7 +284,7 @@ the OpenShift environment is set in `env.json`, and then set `SEND_EMAIL` to the
 variable set, the `env` block of the pod configuration file will look something like this:
 
 ```
--env
- - name: SEND_EMAIL
-   value: "True"
+- env:
+    - name: SEND_EMAIL
+      value: "True"
 ```

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ staff. To designate a course and assignments in Canvas you would like synchroniz
     1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the
        "OK" button.
     1. After the import is complete, you will see "ArcGIS Group" in your course's list of outcomes.
-1. Each of your course's assignments which are to be synchronized with ArcGIS Online needs to include the "ArcGIS Group"
-   outcome in its rubric. **_You will need to do this for each new assignment you add to the course._** This can be
-   simplified somewhat by adding the "ArcGIS Group" outcome to a single rubric that will be used by multiple 
+1. Each of your course's assignments which are to be synchronized with ArcGIS Online needs to include the "ArcGIS 
+   Group" outcome in its rubric. **_You will need to do this for each new assignment you add to the course._** This can 
+   be simplified somewhat by adding the "ArcGIS Group" outcome to a single rubric that will be used by multiple 
    assignments. Each assignment that uses that rubric will automatically include the "ArcGIS Group" outcome. It's 
    recommended that rubrics should be given meaningful names. For example, a good name could be "_your course name 
    here_ Rubric (with ArcGIS sync)".
@@ -80,8 +80,8 @@ staff. To designate a course and assignments in Canvas you would like synchroniz
     1. Edit the assignment's rubric (or add a new rubric if one doesn't already exist).
     1. Click on "🔍 Find Outcome".
     1. In the dialog box of your course's outcomes that appears, click "ArcGIS Group" in the list on the left side of 
-       the box. (Note: **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space to the right
-       of the list.)
+       the box. (Note: **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space to the 
+       right of the list.)
     1. At the bottom right corner of the dialog box, click the "Import" button.
     1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the
        "OK" button.
@@ -124,7 +124,8 @@ Within your instance of ArcGIS, do the following:
 For the application to run, environment variables need to be made available through a JSON file named **env.json** 
 (or similar). This file provides key-value pairs that help the application access necessary accounts, find Canvas 
 entities, and send emails. The application imports this file and uses its values to round out a few configuration 
-classes defined in `config.py` (see the Installation section below for how to embed this file in the application). 
+classes defined in `config.py` (see the **Installation & Development** section below for how to embed this file in the 
+application). 
 
 The `env.json` file contains sensitive information, including account login information and an API secret, and thus 
 needs to be kept out of source control. Teaching & Learning maintains production, test, and local development versions 
@@ -140,13 +141,13 @@ The meanings of the keys and their expected values are described in the table be
 
 **Key** | **Description**
 ----- | -----
-`Logging_Level` | The minimum level for log messages that will appear in output. `INFO` or `DEBUG` is recommended for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html) for more info.
+`Logging_Level` | The minimum level for log messages that will appear in output. `INFO` or `DEBUG` is recommended for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html).
 `Logging_Directory` | The path where log files will be written (see **OpenShift** under Installation & Development for a description of an OpenShift-related restriction on this value).
 `SMTP_Server` | The name of the server emails should be sent from, if the `--email` flag is in use.
 `Email_Sender_Address` | The name and email address to use in the FROM header of emails sent. This should take the form of "\\"Severus Snape\\" <halfbloodprince@umich.edu>" (make sure to escape double quotes).
 `Canvas_Base_URL` | The URL of the Canvas instance you want to pull Canvas data from; for production at UM, this is `umich.instructure.com`.
 `Canvas_API_Token` | The API token to use when making requests for data related to courses, assignments, and users.
-`Canvas_Config_Course_ID` | The ID number of the configuration course, (see the **Canvas** configuration section above).
+`Canvas_Config_Course_ID` | The ID number of the configuration course, (see the **Canvas** Configuration section above).
 `ArcGIS_Org_Name` | The name of the ArcGIS organization in use.
 `ArcGIS_Username` | The name of an arcGIS user with permission for creating and modifying user groups.
 `ArcGIS_Passowrd` | The name of the password for the username provided above.
@@ -156,9 +157,9 @@ The meanings of the keys and their expected values are described in the table be
 ## <a name='installationAndDevelopment'></a>Installation & Development
 
 The sections below provide instructions for installing and running the application in various environments. Before
-attempting to install or deploy, ensure the configuration steps under **For Administrators & Developers** in Configuration
-have been completed. Depending on the environment you plan to run the application in, you may also need to install some 
-or all of the following:
+attempting to install or deploy, ensure the steps in the **For Administrators & Developers** section in 
+Configuration have been completed. Depending on the environment you plan to run the application in, you may also need 
+to install some or all of the following:
    * Python
    * Git
    * [Docker Desktop](https://www.docker.com/products/docker-desktop)
@@ -197,7 +198,7 @@ To set up the application for use locally or in preparation for development work
 
 #### Sending Email
 
-To send emails with kartograafr, the `main.py` files needs to be executed using the `--email` flag, but configuring
+To send emails with kartograafr, the `main.py` file needs to be executed using the `--email` flag, but configuring
 the application to send email from a local environment requires additional steps. To assist in testing email
 functionality, a Shell script called `runDebugEmail.sh` has been provided that creates a mock email server. To run
 kartograafr with this mock server, do the following:
@@ -237,14 +238,14 @@ Note: Currently, there is no way to test sending emails using Docker on a local 
 
 ### OpenShift
 
-Deploying the application as a job using OpenShift and Jenkins involves several steps, which are beyond the scope of this 
-README. However, it seems appropriate to explain some configuration steps assumed by the `Dockerfile` and unique to this
-application.
+Deploying the application as a job using OpenShift and Jenkins involves several steps, which are beyond the scope of
+this README. However, it seems appropriate to explain some configuration steps assumed by the `Dockerfile` and unique 
+to this application.
 
-* The `env.json` file described in Configuration needs to be made available to running kartograafr 
-  containers via an OpenShift ConfigMap, a type of Resource. A volume containing the ConfigMap should be mapped to the 
-  `configuration/secrets` subdirectory. These details will be specified a configuration file (.yaml) defining the 
-  pod.
+* The `env.json` file described in the **Application** section under Configuration needs to be made available to 
+  running kartograafr containers via an OpenShift ConfigMap, a type of Resource. A volume containing the ConfigMap 
+  should be mapped to the `configuration/secrets` subdirectory. These details will be specified in a configuration file
+   (.yaml) defining the pod.
 
 * The kartograafr application writes log files as part of its normal operations. Because of permission restrictions 
   within OpenShift pods, users may need to specify a path for `Logging_Directory` in `env.json` that begins with
@@ -253,10 +254,10 @@ application.
 
 * By default, the application will run without sending email and with the assumption that the JSON file will be named 
   `env.json`. However, the `start.sh` invoked by the `Dockerfile` and `config.py` will also check whether the 
-  environment variables `ENV_FILE` and `SEND_EMAIL` have been defined. These can be set using the pod configuration 
-  file. To use a different name for the JSON file, set `ENV_FILE` to a path beginning with `configuration/secrets/`
-  and ending with the file name. To have the application send email, set `SEND_EMAIL` to the string `"True"`. With these
-  set, the `env` block in the `.yaml` will look something like the following:
+  environment variables `ENV_FILE` and `SEND_EMAIL` have been defined. These can be set using the OpenShift pod 
+  configuration file. To use a different name for the JSON file, set `ENV_FILE` to a path beginning with 
+  `configuration/secrets/` and ending with the file name. To have the application send email, set `SEND_EMAIL` to the 
+  string `"True"`. With these set, the `env` block in the `.yaml` will look something like the following:
 
   ```
   - env:

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ application.
 
 * The kartograafr application writes log files as part of its normal operations. Because of permission restrictions 
   within OpenShift pods, users may need to specify a path for `Logging_Directory` in `env.json` that begins with
-  `tmp`. The U-M configuration uses `tmp/log/kartograafr`.
+  `tmp`. The U-M configuration uses `tmp/log/kartograafr`. Note that these log files will disappear with the running
+  container.
 
 * By default, the application will run without sending email and with the assumption that the JSON file will be named 
   `env.json`. However, the `start.sh` invoked by the `Dockerfile` and `config.py` will also check whether the 

--- a/README.md
+++ b/README.md
@@ -1,240 +1,262 @@
 # kartograafr
 ArcGIS/Canvas data bridge
 
-## About
+## Table of Contents
+
+1. [Overview](#overview)
+    * About
+    * Purpose
+    * Use
+1. [Configuration & Setup](#configurationAndSetup)
+    * For Instructors
+    * For Administrators & Developers
+        * Canvas
+        * ArcGIS
+        * Application
+1. [Installation & Development](#installationAndDevelopment)
+    * Local Development
+        * Sending Email
+    * Docker
+    * OpenShift
+
+## <a name='overview'></a>Overview
+
+### About
 **_kartograafr_** — "kart-uh-GRAFF-fur", or in IPA: ['kɑr.toː.*ɣraːf.fər]
 
-The name is based on the Dutch word for cartographer, "cartograaf", and was changed a little to make it unique.  It is never capitalized.  Since kartograafr is written in Python, a programming language created by a Dutch computer programmer (Guido van Rossum), a Dutch-based name is only fitting.
+The name is based on the Dutch word for cartographer, "cartograaf", and was changed a little to make it unique. It is 
+never capitalized. Since kartograafr is written in Python, a programming language created by a Dutch computer 
+programmer (Guido van Rossum), a Dutch-based name is only fitting.
 
-## Purpose
-The kartograafr application...
+### Purpose
+The kartograafr application ...
 
-* searches for Canvas courses and their assignments which are associated with a specific Canvas outcome object,
-* creates or updates ArcGIS groups that contain the users of the Canvas course assignments it found,
-* reads part of its configuration (course IDs to be checked) from a page in a specific Canvas course used only for this purpose,
-* can be easily updated by changing its configuration course page in Canvas,
-* allows support staff to update its configuration via Canvas without requiring server sysadmin access
+* searches for Canvas courses and their assignments that are associated with a specific Canvas outcome object
+* creates and/or updates ArcGIS groups so that they contain the users of the Canvas course assignments found
+* reads part of its configuration (course IDs to be checked) from a page in a specific Canvas course used only for this 
+  purpose
+* allows support staff to easily update via Canvas the courses to be synchronized with ArcGIS
+
+### Use
+kartograafr is maintained by ITS Teaching & Learning at the University of Michigan. The unit runs the service to 
+support courses at the university that rely on ArcGIS for student assignments. Teaching & Learning currently runs the 
+application as a scheduled job using [Docker](https://docs.docker.com/) containerization technology, the 
+[OpenShift Container Platform](https://docs.openshift.com/), and an instance of the 
+[Jenkins automation server](https://jenkins.io/doc/).
 
 ----------------
 
-## Running as a service
-
-### For Administrators: Setup and Installation
-##### Docker instance configuration
-
-The kartograafr service runs in a Docker container.  Configuring
-the container requires setting values in three files: **config.py**
-and **secrets.py** and kartograafr cron tab file **kartograafr**.
-
-The **config.py** file  contains environment values for the Canvas and
-ArcGIS and mail server connections and log file names.  It also contains information on
-where to get assignment information within the Canvas instance.
-This file contains dummy values for api tokens, account names and passwords.
-These values are overridden in the **secrets.py** file.
-
-Since different configurations are required for development and
-production there are multiple copies of the config.py and crontab file
-in source control under instance appropriate names.  The Docker
-container uses an initialization script that will install the
-appropriate files for the container.  See below.
-
-
-
-##### Initial Canvas configuration
-
-1. In Canvas:
-    1. Make note of the Canvas API base URL
-    1. Make note of the Canvas account ID number being used for the following items
-    1. Prepare an API access token
-    1. Create an outcome for ArcGIS and note its ID number
-    1. Create a kartograafr configuration course and note its ID number
-        1. Create a page named `course-ids`
-        1. Add to the page the URLs of courses to be processed (they will appear as links on the page)
-        1. Give support staff the permissions necessary to update that
-        page (add them with the "Teacher" role)
-
-##### Initial ArcGIS configuration
-1. In ArcGIS:
-    1. Make note of the organization name being used (e.g., `devumich` or `umich`)
-    1. Create a user with permission to create and modify user groups,
-    make note of the username and password
-
-##### Python configuration
-1. Update `/usr/local/apps/kartograafr/config.py` as necessary
-    1. Add configuration values from Canvas
-        1. API base URL and token
-        1. Account ID number
-        1. ArcGIS outcome ID number
-        1. kartograafr configuration course ID number
-        1. kartograafr configuration course page name (i.e., `course-ids`)
-        1. *Optional*: Add a set of course IDs to process.  This is used as a backup if the configuration course page is misformatted or corrupted.  It may also be used *in place of* the configuration course and page.
-    1. Add configuration values from ArcGIS
-        1. Organization name
-        1. Username and password
-        1. Review email and logging settings and update them
-
-
+## <a name='configurationAndSetup'></a>Configuration & Setup
 
 ### For Instructors
-#### Designate Course and Assignments To Be Synchronized
 
-1. Email `4-HELP@umich.edu` to request that your course be added to the list of courses on the "kartograafr: Canvas/ArcGIS Integration" configuration page.  This will only need to be requested once for each of your courses.  You may proceed to the next step while you wait for this request to be fulfilled.
-1. Add the "ArcGIS Group" outcome to your course.  This will only need to be done once for each of your courses.
+The kartograafr service was designed so that it can be set up easily for a course by instructors and other support
+staff. To designate a course and assignments in Canvas you would like synchronized with ArcGIS, do the following:
+
+1. Email `4-HELP@umich.edu` to request that your course be added to the list of courses on the "kartograafr: 
+   Canvas/ArcGIS Integration" configuration page. This will only need to be requested once for each of your courses. 
+   You may proceed to the next step while you wait for this request to be fulfilled.
+1. Add the "ArcGIS Group" outcome to your course. This will only need to be done once for each of your courses.
     1. On your course's home page, click the "Outcomes" navigation item.
-    1. On your course's Outcome page, click the "🔍 Find" button.  (Note: **_DO NOT_** click the "+ Outcome" button.)
+    1. On your course's Outcome page, click the "🔍 Find" button. (Note: **_DO NOT_** click the "+ Outcome" button.)
     1. In the dialog box that appears, select the following list items, in order:
         1. "Account Standards"
         1. "University of Michigan - Ann Arbor"
         1. "ArcGIS"
-        1. "ArcGIS Group".  (Note: Only click the "ArcGIS Group" item in the list immediately to the right of the "ArcGIS" item.  **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space in the rightmost part of the dialog box.)
+        1. "ArcGIS Group". (Note: Only click the "ArcGIS Group" item in the list immediately to the right of the 
+           "ArcGIS" item. **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space in the 
+           rightmost part of the dialog box.)
     1. At the bottom right corner of the dialog box, click the "Import" button.
-    1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the "OK" button.
+    1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the
+       "OK" button.
     1. After the import is complete, you will see "ArcGIS Group" in your course's list of outcomes.
-1. Each of your course's assignments which are to be synchronized with ArcGIS Online needs to include the "ArcGIS Group" outcome in their rubrics.  **_You will need to do this for each new assignment you add to the course._**  
-
-    This can be simplified somewhat by adding the "ArcGIS Group" outcome to a single rubric that will be used by multiple assignments.  Each assignment that uses that rubric will automatically include the "ArcGIS Group" outcome.  It's recommended that rubrics should be given meaningful names.  For example, a good name could be "_your course name here_ Rubric (with ArcGIS sync)".
+1. Each of your course's assignments which are to be synchronized with ArcGIS Online needs to include the "ArcGIS Group"
+   outcome in their rubrics. **_You will need to do this for each new assignment you add to the course._** This can be
+   simplified somewhat by adding the "ArcGIS Group" outcome to a single rubric that will be used by multiple 
+   assignments. Each assignment that uses that rubric will automatically include the "ArcGIS Group" outcome. It's 
+   recommended that rubrics should be given meaningful names. For example, a good name could be "_your course name 
+   here_ Rubric (with ArcGIS sync)".
     1. Click on the name of an assignment in the list of your course's assignments.
     1. Edit the assignment's rubric (or add a new rubric if one doesn't already exist).
     1. Click on "🔍 Find Outcome".
-    1. In the dialog box of your course's outcomes that appears, click "ArcGIS Group" in the list on the left side of the box.  (Note: **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space to the right of the list.)
+    1. In the dialog box of your course's outcomes that appears, click "ArcGIS Group" in the list on the left side of 
+       the box. (Note: **_DO NOT_** click on the larger "ArcGIS Group" link that appears in the wider space to the right
+       of the list.)
     1. At the bottom right corner of the dialog box, click the "Import" button.
-    1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the "OK" button.
+    1. In the alert box with the message "Import outcome 'ArcGIS Group' to group '_your course name here_'?", click the
+       "OK" button.
     1. After the import is complete, you will see "ArcGIS Group" as part of the assignment's rubric.
     1. Finally, click the "Update Rubric" button (or the "Create Rubric" button if you were adding a new rubric).
-1. Control the synchronization of your assignment with ArcGIS online by setting the "Available From", "Until", and "Due Date" times.
-1. Once all of the above requirements are satisfied, kartograafr will synchronize your course's assignments with ArcGIS Online.  It will happen automatically, several times each day.  You will receive email a few times each day showing the results of the synchronizations.
+1. Control the synchronization of your assignment with ArcGIS online by setting the "Available From", "Until", and 
+   "Due Date" times.
+   
+Once all of the above requirements are satisfied, kartograafr will synchronize your course's assignments with ArcGIS
+Online. It will happen automatically, several times each day.
+
+### For Administrators and Developers
+
+To set up the application, users will need to perform configuration steps in the Canvas and ArcGIS instances that they
+want to connect, and specify environment variables to connect to those instances and determine other application
+settings. The following sections provide instructions for how to complete this configuration. (Note: UM-affiliated 
+users should contact Teaching & Learning, as much of this configuration is already in place.)
+
+#### Canvas
+
+Within your instance of Canvas, do the following:
+
+1. Create an API access token.
+1. Record the base URL of the Canvas API.
+1. Create an outcome for ArcGIS and record its ID number.
+1. Create a kartograafr configuration course and record its ID number.
+    1. Within the new configuration course, create a page named `course-ids`.
+    1. Add to the page the URLs of courses to be processed (they will appear as links on the page).
+    1. Give support staff the permissions necessary to update that page (add them with the "Teacher" role).
+
+#### ArcGIS
+
+Within your instance of ArcGIS, do the following:
+
+1. Record the organization name in use (e.g., at UM, `devumich` or `umich`)
+1. Create a user with permission to create and modify user groups, and record the username and password.
+
+### Application
+
+For the application to run, environment variables need to be made available through a JSON file named **env.json** 
+(or similar). This file provides key-value pairs that help the application access necessary accounts, find Canvas 
+entities, and send emails. The application imports this file and uses its values to round out a few configuration 
+classes defined in `config.py` (see the Installation section below for how to embed this file in the application). 
+
+The `env.json` file contains sensitive information, including account login information and an API secret, and thus 
+needs to be kept out of source control. Teaching & Learning maintains production, test, and local development versions 
+of these files outside of GitHub. A template JSON file called `env_blank.json` has been provided as a starting point.
+
+To create your version of this file, do the following:
+
+1. Copy `env_blank.json`.
+1. Rename the file `env.json` (for use in local development) or `[some name].json` (for use in OpenShift).
+1. Replace the empty strings and 0's with the desired settings and values.
+
+The meaning of each key and its expected value are described in the table below.
+
+**Key** | **Description**
+----- | -----
+`Logging_Level` | The minimum level for log messages that will appear in output. We recommend either `INFO` or `DEBUG` for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html) for more info.
+`Logging_Directory` | The path where log files will be written; in OpenShift, this needs to be the `tmp` directory of the container's file system.
+`SMTP_Server` | The name of the server emails should be sent from, if the `--email` flag is in use.
+`Email_Sender_Address` | The name and email address to use in the FROM header of emails sent. This should take the form of "\"Severus Snape"\ <halfbloodprince@umich.edu>" (make sure to escape double quotes).
+`Canvas_Base_URL` | The URL of the Canvas instance you want to pull Canvas data from; for production at UM, this is `umich.instructure.com`.
+`Canvas_API_Token` | The API token to use when making requests for data related to courses, assignments, and users.
+`Canvas_Config_Course_ID` | The ID number of the configuration course, (see the **Canvas** configuration section above).
+`ArcGIS_Org_Name` | The name of the ArcGIS organization in use.
+`ArcGIS_Username` | The name of an arcGIS user with permission for creating and modifying user groups.
+`ArcGIS_Passowrd` | The name of the password for the username provided above.
 
 ----------------
 
-## Development
+## <a name='installationAndDevelopment'></a>Installation & Development
 
-### Python Environment / ArcGIS / Anaconda
+The sections below provide instructions for installing and running the application in various environments. Before
+attempting to install or deploy, ensure the configuration steps under **For Administrators and Developers** have been
+completed. Depending on the environment you plan to run the application in, you may also need to install some or all
+of the following:
+   * Python
+   * Git
+   * Docker Desktop
+   * OpenShift CLI
 
-The newest release of the ArcGIS Python API is only distributed via
-the Anaconda environment manager.  For local development you'll need
-to install Anaconda (see https://www.anaconda.com/download) and use it to create a virtual environment in Python 3.
+### Local Development
+
+To set up the application for use locally or in preparation for development work, do the following:
+
+1. Clone the repository, and navigate into the repository.
+   ```
+   https://github.com/tl-its-umich-edu/kartograafr.git  # HTTPS
+   git@github.com:tl-its-umich-edu/kartograafr.git  # SSH
+   
+   cd kartograafr
+   ```
+1. Create a virtual environment using `virtualenv`.
+   ```
+   virtualenv venv
+   source venv/bin/activate  # for Mac OS
+   ```
+1. Install the dependencies in `requirements.txt`.
+   ```
+   pip install -r requirements.txt
+   ```
+1. Install the `arcgis` package separately.
+   ```
+   pip install arcgis --no-deps
+   ```
+1. Place the `env.json` file previously created in the `configuration/secrets/` directory.
+
+1. Run the application.
+   ```
+   python main.py
+   ```
+
+#### Sending Email
+
+To send emails with kartograafr, the `main.py` files needs to be executed using the `--email` flag, but configuring
+the application to send email from a local environment requires additional steps. To assist in testing email
+functionality, a Shell script called `runDebugEmail.sh` has been provided that creates a mock email server. To run
+kartograafr with this mock server, do the following:
+
+1. Ensure the `SMTP_Server` value in `env.json` is set to `localhost:1025`.
+1. Execute the Shell script to start the server.
+   ```
+   /bin/bash runDebugEmail.sh
+   ```
+1. In a separate shell, terminal, or console window, run `main.py`.
+   ```
+   python main.py --email
+   ```
+The email will appear in the window where you ran the Shell script.
+
+Alternatively, you can print the email content as part of application's output (without using the mock server) by 
+passing the `--printEmail` flag when executing `main.py`.
 ```
-conda create --name py35 python=3.5
-source activate py35
+python main.py --email --printEmail
 ```
-
-Once Anaconda is installed and Python 3 virtual environment is created
-and activated
-install the ArcGIS api by running  
-```
-conda install -c esri arcgis
-```
-Also install any required packages by running:
-```
-pip install -r requirements.text
-```
-
-Note that this python environment must be used in testing or running kartograafr.
-
-### Testing Locally
-
-To run the kartograafr scan of ArcGIS a single time from the local machine (not Docker) and check the python installation, use:
-```
-USE_CONDA_ENV=py35 ./startup.sh
-```
-
-Some local files must be available for local testing. The exact
-locations of the files is specified by your local configuration.  **The
-log configuration in config.py must point to existing directories.** This may require creating the /var/log/kartograafr directory and setting permissions to be universally writeable.
-The **secrets.py** file must be available from a directory that has
-been added to the PYTHONPATH.
-
-#### Local mail server
-
-When testing locally you can setup a mock email server for
-testing. Typically a Python installation provides a debugging smtpd
-that can be started with the command:
-
-```
-python -m smtpd -n -c DebuggingServer localhost:1025
-```
-
-#### Starting kartograafr
-
-A *startup.sh* script is now provided to invoke kartagraafr.  This
-script can be run from the OSX command line or in a Docker container.
-It automatically accounts for the environmental differences.  A
-startup script is exceedingly helpful for running the program under
-cron in Docker.  It's also very convenient in making it possible to
-run kartograafr from the command line during development without
-requiring running Docker.  One very important function of the startup
-script is to make the *secrets* directory with the secure connection
-information available to the application.  See the script for more
-details.
-
-kartograafr can also be run directly under Eclipse. The Eclipse
-project will need to be setup to use the appropriate Ananconda virtual
-environment.  It's likely to work with other IDEs but YMMV.
-
 
 ### Docker
 
-#### Running kartograafr in  Docker locally
+When developing locally, you can also run the application by leveraging the `Dockerfile` and Docker Desktop. To run
+with Docker, do the following:
 
-The *runDocker.sh* script will configure and build a local Docker
-container for kartograafr and will setup a Docker environment that
-allows running that container on OSX. This script  is not needed when running
-on OpenShift since that provides a rich environment of services.
-A Dockerfile is provided for local development. It assumes that the
-code has been checked out already.  
+1. Build an image.
+   ```
+   docker build -t kartograafr .
+   ```
+2. Run a container using the tagged image.
+   ```
+   docker run kartograafr
+   ```
 
-To run on a local Docker environment, use
-```
-./runDocker.sh
-```
-This will display status information during setup, as well as the current crontab file to give information on scheduled runs. This can be used to determine when the next kartograafr scan should run. If errors are encountered when it runs or during the setup steps that are related to directory structure or file permissions on the Docker container, open another terminal window, navigate to the kartograafr folder, and use
-```./dol bash``` to open bash in the Docker container. (The **dol** script contains shortcuts to run a number of commands on the local Docker container, when only a single container is running.)
-
-#### Docker Considerations: Volatile Storage
-
-Using Docker for the run time environment has some design implications, discussed below.
-
-The running instance may be restarted at any time because of
-maintenance or an administrative need to move a running instance to
-different physical server. In addition if the application uses scaling to provide
-capacity then additional copies of the instance may be started and removed
-without warning.  This means that the instance should not rely on
-storing critical information in memory. A running instance should not assume that it
-is the only instance using data unless that restriction is part of the
-run time configuration.
-
-The file system in the instance is volatile.  The application can read
-and write to the local file system but a restart will make those
-changes vanish.  Docker *can* easily be configured to map external
-persistant disk to internal file system directories but that must be
-configured explicitly when invoking Docker.
+Note: Currently, there is no way to test sending emails using Docker on a local machine.
 
 ### OpenShift
 
-Applications that run under Docker are usually easy to run on
-OpenShift.  There will be configuration changes.  OpenShift
-configuration is beyond the scope of this readme.  The *runDocker.sh*
-script is a model for what OpenShift needs to be configured to supply.
+Running the application as a job using OpenShift and Jenkins involves several steps, which are beyond the scope of this 
+README. However, it seems appropriate to explain some configuration steps assumed by the `Dockerfile` and unique to this
+application.
 
-------
+* The `env.json` file described during the Configuration steps needs to be made available to running kartograafr 
+  containers via an OpenShift ConfigMap, a type of Resource. A volume containing the ConfigMap should be mapped to the 
+  `configuration/secrets` subdirectory. These details will be specified a configuration file (.yaml) defining the 
+  pod.
 
-###  Secure Information
+* By default, the application will run without sending email and with the assumption that the JSON file will be named 
+  `env.json`. However, the `start.sh` invoked by the `Dockerfile` and `config.py` will also check whether the 
+  environment variables `ENV_FILE` and `SEND_EMAIL` have been defined. These can be set using the pod configuration 
+  file. To use a different name for the JSON file, set `ENV_FILE` to a path beginning with `configuration/secrets/`
+  and ending with the file name. To have the application send email, set `SEND_EMAIL` to the string `"True"`. The `env`
+  block in the `.yaml` will look something like the following:
 
-Any secure or authentication information needs to be
-kept out of source control and be strictly separated from normal
-properties.  That information is expected to be found in the
-*secrets.py* module which will be available in a separate secrets directory.
-A template for a secrets file is in the the configuration directory.
-That template shouldn't be modified but should be copied and that copy
-should be read from the separate secure directory.
-
-When running locally the *startup.sh* script assumes that the
-secrets.py file is available in the subdirectory *./OPT/SECRETS*.
-That reference can be a symbolic link to the actual location.  On
-OpenShift the location will be set in the deployment
-configuration. See the OpenShift kartograafr dev project to see how it
-is configured.
-
-The template file illustrates how to easily implement an environmental variable
-override of the property value.  The code given is very likely not the
-best way to do this and is likely to be improved soon.
+  ```
+  - env:
+     - name: ENV_FILE
+       value: /configuration/secrets/env_test.json
+     - name: SEND_EMAIL
+       value: "True"
+  ```


### PR DESCRIPTION
This PR makes updates to the README to reflect significant changes to the configuration and deployment processes, particularly the use of `env.json` and the removal of `cron` functionality. It also includes some improvements to formatting, re-organizing of existing content, the addition of a TOC, and other grammatical changes. The PR aims to resolve issue #32.