### PR TITLE
Perform dependency update, simplify development with Docker (#48)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 **/env.json
-
+**/__pycache__
 venv
-__pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/env.json
+
+venv
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Use a Python base image
-FROM python:3.7
+FROM python:3.8-slim
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 
 # arcgis needs to be installed separately because of issues when including the requirement with a flag in
 # requirements.txt
-RUN pip install arcgis --no-deps
+RUN pip install arcgis==1.9.0 --no-deps
 
 WORKDIR /kartograafr/
 COPY . /kartograafr/

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The meanings of the keys and their expected values are described in the table be
 `Canvas_Config_Course_ID` | The ID number of the configuration course, (see the **Canvas** Configuration section above).
 `ArcGIS_Org_Name` | The name of the ArcGIS organization in use.
 `ArcGIS_Username` | The name of an arcGIS user with permission for creating and modifying user groups.
-`ArcGIS_Passowrd` | The name of the password for the username provided above.
+`ArcGIS_Password` | The name of the password for the username provided above.
 
 ----------------
 
@@ -179,25 +179,29 @@ For either option, first you'll need to do the following:
     
     cd kartograafr
     ```
-2. Place the `env.json` file previously created in the `configuration/secrets/` directory.
 
 #### With Docker
 
-You can run the application without installing the dependencies manually by leveraging the `Dockerfile` and Docker 
-Desktop. To run with Docker, do the following:
+You can run the application without installing the dependencies manually by leveraging the `Dockerfile`,
+`docker-compose.yml`, and Docker Desktop. To run with Docker, do the following:
+
+1. Place the `env.json` file previously created in the `{HOME}/secrets/kartograafr` directory,
+   where `{HOME}` is your user's home directory, or `~`.
 
 1. Build an image.
    ```
-   docker build -t kartograafr .
+   docker compose build
    ```
 1. Run a container using the tagged image.
    ```
-   docker run kartograafr
+   docker compose up
    ```
 
 #### With a Virtual Environment
 
 You can also set up the application using `virtualenv` by doing the following:
+
+1. Place the `env.json` file previously created in the `configuration/secrets` directory in the repository.
 
 1. Create a virtual environment using `virtualenv`.
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  job:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ${HOME}/secrets/kartograafr:/kartograafr/configuration/secrets
+      - .:/kartograafr
+    container_name: kartograafr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 # Note: this does not include arcgis, which needs to be installed manually when using virtualenv.
 # Use the following command: pip install arcgis --no-deps
 
-bs4==0.0.1
-python-dateutil==2.8.1
-requests==2.22.0
-url-normalize==1.4.1
+beautifulsoup4==4.9.3
+ntlm-auth==1.5.0
+python-dateutil==2.8.2
+requests==2.26.0
+requests-toolbelt==0.9.1
+requests_ntlm==1.1.0
+six==1.16.0
+url-normalize==1.4.3
+ujson==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ requests==2.26.0
 requests-toolbelt==0.9.1
 requests_ntlm==1.1.0
 six==1.16.0
-url-normalize==1.4.3
 ujson==4.1.0
+url-normalize==1.4.3


### PR DESCRIPTION
This PR updates the Python base image to 3.8 (and uses `-slim` to keep the image small), updates the `pip` dependencies, pins `arcgis` in the separate `Dockerfile` step, and then adds more Docker artifacts, including a `.dockerignore` and a `docker-compose.yml`. The PR aims to resolve #48.