### PR TITLE
Update dependencies again (#48)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Use a Python base image
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 
 # arcgis needs to be installed separately because of issues when including the requirement with a flag in
 # requirements.txt
-RUN pip install arcgis==1.9.0 --no-deps
+RUN pip install arcgis==1.9.1 --no-deps
 
 WORKDIR /kartograafr/
 COPY . /kartograafr/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Note: this does not include arcgis, which needs to be installed manually when using virtualenv.
 # Use the following command: pip install arcgis --no-deps
 
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
+cachetools==4.2.4
 ntlm-auth==1.5.0
 python-dateutil==2.8.2
 requests==2.26.0


### PR DESCRIPTION
This is a follow-up to PR #49 to bump the Python base image to `3.9-slim`, the `arcgis` module to `1.9.1`, and the `beautifulsoup4` module to `4.10.0`. `cachetools` was also added, as it now appears to be a minimum dependency of `arcgis` (follow this post [here](https://community.esri.com/t5/arcgis-api-for-python-questions/minimum-dependencies-for-arcgis-1-9-1/m-p/1134432#M7015)).

Note(s):
- I held back on available updates to `ujson`, `requests`, and `cachetools` (chose second to latest when adding), because they came after the latest `arcgis` release; let me know if that makes sense to you, or if I should go ahead with updating them.