### PR TITLE
Upgrade Python and resolve resulting dependency errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-**/env.json
-**/__pycache__
-venv

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/env.json
+**/__pycache__
+venv
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-# Use a Python base image
-FROM python:3.8-slim
+FROM python:3.13-slim
 
 COPY requirements.txt /requirements.txt
-RUN pip install -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    pip install -r requirements.txt
 
-# arcgis needs to be installed separately because of issues when including the requirement with a flag in
-# requirements.txt
+# ArcGIS must be installed separately because some of its dependencies cause
+# conflicts, but we don't need those dependencies.  We cannot use the
+# `--no-deps` flag in `requirements.txt`, so we install ArcGIS separately.
 RUN pip install arcgis==1.9.0 --no-deps
 
 WORKDIR /kartograafr/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ RUN apt-get update && \
     pip install -r requirements.txt && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# ArcGIS must be installed separately because some of its dependencies cause
-# conflicts, but we don't need those dependencies.  We cannot use the
-# `--no-deps` flag in `requirements.txt`, so we install ArcGIS separately.
-RUN pip install arcgis==1.9.0 --no-deps
-
 WORKDIR /kartograafr/
 COPY . /kartograafr/
 
@@ -19,5 +14,3 @@ ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 CMD ["/bin/bash", "start.sh"]
-
-# Done!

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.13-slim
 COPY requirements.txt /requirements.txt
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential && \
-    pip install -r requirements.txt
+    pip install -r requirements.txt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ArcGIS must be installed separately because some of its dependencies cause
 # conflicts, but we don't need those dependencies.  We cannot use the

--- a/arcgisUM.py
+++ b/arcgisUM.py
@@ -1,16 +1,17 @@
 # Wrapper around calls to arcgis. Helps with testing and future changes.
 
-# standard modules
-import datetime, logging, json, traceback
-from operator import itemgetter
+import datetime
+import json
+import logging
+import traceback
 from io import StringIO
+from operator import itemgetter
 
-# third-party modules
-import arcgis, dateutil.tz
+import arcgis
+import dateutil.tz
 
-# local modules
-from configuration import config
 import util
+from configuration import config
 
 
 # global variables and logging setup

--- a/configuration/config.py
+++ b/configuration/config.py
@@ -1,5 +1,7 @@
 import json, os
 
+ENV = {}
+
 try:
     with open(os.getenv("ENV_FILE", "configuration/secrets/env.json")) as env_file:
         ENV = json.load(env_file)

--- a/configuration/config.py
+++ b/configuration/config.py
@@ -2,11 +2,12 @@ import json, os
 
 ENV = {}
 
+env_file_path = os.getenv("ENV_FILE", "configuration/secrets/env.json")
 try:
-    with open(os.getenv("ENV_FILE", "configuration/secrets/env.json")) as env_file:
+    with open(env_file_path) as env_file:
         ENV = json.load(env_file)
 except FileNotFoundError as fnfe:
-    print("Default config file was not found. This is normal for the build; it should be provided for operation.")
+    raise RuntimeError(f'Config file "{env_file_path}" was not found.')
 
 
 class Application(object):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  job:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      # Look for secrets in `secrets/kartograafr` within one of the following:
+      # 1. The directory specified by the CONFIG_DIR environment variable
+      # 2. The user's home directory
+      - ${CONFIG_DIR:-${HOME}}/secrets/kartograafr:/kartograafr/configuration/secrets
+      - .:/kartograafr
+    container_name: kartograafr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   job:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  job:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    volumes:
-      - ${HOME}/secrets/kartograafr:/kartograafr/configuration/secrets
-      - .:/kartograafr
-    container_name: kartograafr

--- a/main.py
+++ b/main.py
@@ -1,18 +1,23 @@
 # standard modules
-import argparse, logging, os, re, smtplib, sys, traceback
+import argparse
+import logging
+import os
+import re
+import smtplib
+import sys
+import traceback
 from datetime import datetime
 from email.message import EmailMessage
 
-# third-party modules
+import dateutil.parser
+import dateutil.tz
 from bs4 import BeautifulSoup
 from bs4.builder._htmlparser import HTMLParserTreeBuilder
-import dateutil.parser, dateutil.tz
 
-# local modules
 import arcgisUM
+import util
 from CanvasAPI import CanvasAPI
 from configuration import config
-import util
 
 
 # global variables and logging setup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Note: this does not include arcgis, which needs to be installed manually when using virtualenv.
-# Use the following command: pip install arcgis --no-deps
+# Note: this does not include ArcGIS, which must be installed separately when
+# using containers.  See `Dockerfile` for more information.
 
 beautifulsoup4==4.9.3
 ntlm-auth==1.5.0
@@ -8,5 +8,6 @@ requests==2.26.0
 requests-toolbelt==0.9.1
 requests_ntlm==1.1.0
 six==1.16.0
-ujson==4.1.0
+standard-imghdr==3.13.0
+ujson==5.10.0
 url-normalize==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 arcgis==2.4.2
 beautifulsoup4==4.14.2
+python-dateutil==2.9.0.post0
+requests==2.32.5
 url-normalize==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,3 @@
-# Note: this does not include ArcGIS, which must be installed separately when
-# using containers.  See `Dockerfile` for more information.
-
-beautifulsoup4==4.9.3
-ntlm-auth==1.5.0
-python-dateutil==2.8.2
-requests==2.26.0
-requests-toolbelt==0.9.1
-requests_ntlm==1.1.0
-six==1.16.0
-standard-imghdr==3.13.0
-ujson==5.10.0
-url-normalize==1.4.3
+arcgis==2.4.2
+beautifulsoup4==4.14.2
+url-normalize==2.2.1

--- a/start.sh
+++ b/start.sh
@@ -11,5 +11,3 @@ else
   echo "Running kartograafr WITHOUT email flag"
   python main.py
 fi
-
-# The End


### PR DESCRIPTION
Resolves #59.

Upgrade to Python 3.13 because the version currently used in production (3.8) is no longer available.

It first seemed as though upgrading the ArcGIS module would be required.  After working with this for several days, that turns out not to be the case.  The old ArcGIS caused some errors with the new Python, but the new ArcGIS had its own set of errors caused by our code because their API has changed.

It turns out that the old ArcGIS' only problem was that it wanted to use the `imghdr` module, which was a standard Python module, but in recent years had been removed.  By installing a replacement module, `standard-imghdr`, we can temporarily get around that problem.  That gives us more time to work on upgrading ArcGIS and also to get the Python upgrade to production sooner.

## Test Plan

### Test with Jenkins test

0. Prerequisites
	1. This branch, `lsloan:59-python-upgrade` must be pushed upstream.
	2. In OpenShift project `tl-jenkins-test`, edit `bc/kartograafr` to specify branch `59-python-upgrade` as the `ref` for the GitHub repo.  (When not testing specific changes, the usual value for `ref` will be `tags/nnnn.nn.nn`.)
	   ```sh
       oc patch bc/kartograafr -n tl-jenkins-test -p '{"spec":{"source":{"git":{"ref":"59-python-upgrade"}}}}'
       ```
1. Go to https://test-jenkins.tl.it.umich.edu/job/Test-kartograafr_job/, enable the project, and run "Build with Parameters".

### Test locally

1.  Copy `configuration/secrets/env_blank.json` to `${HOME}/secrets/kartograafr/env.json`.  Note that's in the user's home directory, to avoid accidentally committing the configuration to the repository.
    * Alternatively, set `$CONFIG_DIR` with the path of another directory to use instead of the home directory.  The application will look for the file in `${CONFIG_DIR}/secrets/kartograafr/env.json`.
4. Edit the new `env.json` file to set the configuration parameters to appropriate values.
5. Run the app with `docker compose up --build`.
6. The output should show many log lines for communication with the Canvas and the ArcGIS APIs.